### PR TITLE
Set ApplyFrontend to true as recommended in the snowboy README

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -215,6 +215,8 @@ class SnowboyEngine(Engine):
         self._snowboy = snowboydetect.SnowboyDetect(resource_filename=resource_filename,
                                                     model_str=model_str)
         self._snowboy.SetSensitivity(str(sensitivity).encode())
+        self._snowboy.ApplyFrontend(True)
+
 
     @prepare_pcm
     def process(self, pcm):


### PR DESCRIPTION
According to the Snowboy Readme ApplyFrontend should be set to True if resources/alexa/alexa-avs-sample-app/alexa.umdl is used.


> resources/alexa/alexa-avs-sample-app/alexa.umdl:` Universal model for the hotword "Alexa" optimized for Alexa AVS sample app. Set SetSensitivity to 0.6, and set ApplyFrontend to true. This is so far the best "Alexa" model we released publicly, when ApplyFrontend is set to true.